### PR TITLE
split at routes

### DIFF
--- a/app/components/player.hbs
+++ b/app/components/player.hbs
@@ -1,3 +1,4 @@
 <div class="bg-yellow-200 p-4 m-4 border">
+  this is the player component:
   [{{@name}}]
 </div>

--- a/app/helpers/player-helper.js
+++ b/app/helpers/player-helper.js
@@ -1,0 +1,6 @@
+import { helper } from "@ember/component/helper";
+
+export default helper(function playerHelper(params /*, hash*/) {
+  console.log('This should be present in the "players" route bundle');
+  return params;
+});

--- a/app/templates/players.hbs
+++ b/app/templates/players.hbs
@@ -4,4 +4,6 @@
 <Player @name="Ben" />
 <Player @name="Sophie" />
 
+{{player-helper 'hello'}}
+
 {{outlet}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -29,5 +29,6 @@ module.exports = function (defaults) {
     packagerOptions: {
       webpackConfig: {},
     },
+    splitAtRoutes: ["teams", "players", "table"],
   });
 };

--- a/tests/integration/helpers/player-helper-test.js
+++ b/tests/integration/helpers/player-helper-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | player-helper', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{player-helper inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1234');
+  });
+});


### PR DESCRIPTION
It seems that colocated components aren't yet spit: https://github.com/embroider-build/embroider/issues/310

You can see that the `Player` component source is included in the main payload, even though it's only used on the `players` route and we are splitting on `splitAtRoutes: ["teams", "players", "table"]`

![embroider-loading](https://user-images.githubusercontent.com/2526/84032424-3b634380-a98f-11ea-9d58-a89d15f7cb86.gif)
