### PR TITLE
add ember-truth-helpers

### DIFF
--- a/app/templates/teams.hbs
+++ b/app/templates/teams.hbs
@@ -1,5 +1,11 @@
 <h2>Teams:</h2>
 
+{{#if (is-array (array 1 2 3))}}
+  <div class="p-4 m-4 bg-green-600 text-white">
+    [1, 2, 3] is an array
+  </div>
+{{/if}}
+
 <Team @name="Alexs' Team" />
 <Team @name="Ben's Team" />
 <Team @name="Sophie's Team" />

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ember-resolver": "^8.0.0",
     "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/canary/shas/9c1b4e8ad6226b559605d34be22338af9ffc31aa.tgz",
     "ember-template-lint": "^2.6.0",
+    "ember-truth-helpers": "^2.1.0",
     "eslint": "^6.8.0",
     "eslint-plugin-ember": "^8.4.0",
     "eslint-plugin-node": "^11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5427,6 +5427,13 @@ ember-test-waiters@^1.1.1:
     ember-cli-babel "^7.11.0"
     semver "^6.3.0"
 
+ember-truth-helpers@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-2.1.0.tgz#d4dab4eee7945aa2388126485977baeb33ca0798"
+  integrity sha512-BQlU8aTNl1XHKTYZ243r66yqtR9JU7XKWQcmMA+vkqfkE/c9WWQ9hQZM8YABihCmbyxzzZsngvldokmeX5GhAw==
+  dependencies:
+    ember-cli-babel "^6.6.0"
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"


### PR DESCRIPTION
This seems to work well, the `is-array` helper is included in the `"teams"` bundle:

<img width="1432" alt="Screenshot 2020-06-08 at 14 40 19" src="https://user-images.githubusercontent.com/2526/84037220-2d64f100-a996-11ea-984f-3ffc22e3439a.png">
