### PR TITLE
ember-lifeline

### DIFF
--- a/app/components/addons/ember-lifeline.hbs
+++ b/app/components/addons/ember-lifeline.hbs
@@ -1,0 +1,3 @@
+<Addons::Addon @name="ember-moment" class="bg-green-300">
+  The date is [{{this.date}}]
+</Addons::Addon>

--- a/app/components/addons/ember-lifeline.js
+++ b/app/components/addons/ember-lifeline.js
@@ -1,0 +1,23 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { runTask, runDisposables } from "ember-lifeline";
+
+export default class AddonsEmberLifelineComponent extends Component {
+  @tracked date;
+
+  constructor() {
+    super(...arguments);
+
+    runTask(
+      this,
+      () => {
+        this.date = new Date();
+      },
+      500
+    );
+  }
+
+  willDestroy() {
+    runDisposables(this);
+  }
+}

--- a/app/templates/addons.hbs
+++ b/app/templates/addons.hbs
@@ -4,3 +4,4 @@
 <Addons::Lodash />
 <Addons::EmberAnimated />
 <Addons::EmberMoment />
+<Addons::EmberLifeline />

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.1",
     "ember-href-to": "^3.1.0",
+    "ember-lifeline": "^5.1.0",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-moment": "^8.0.0",

--- a/tests/integration/components/addons/ember-lifeline-test.js
+++ b/tests/integration/components/addons/ember-lifeline-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | addons/ember-lifeline', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Addons::EmberLifeline />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <Addons::EmberLifeline>
+        template block text
+      </Addons::EmberLifeline>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5490,6 +5490,14 @@ ember-inflector@^3.0.1:
   dependencies:
     ember-cli-babel "^6.6.0"
 
+ember-lifeline@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ember-lifeline/-/ember-lifeline-5.1.0.tgz#6b7bcde7912333551e0d0643908c2b8511e586a9"
+  integrity sha512-gmGHqroVQ19Z7KLha33hBg/2QNxamsbKRdpJiC46iKirk31KHInS4D3scl6iwMZXWBjHO+5VyTNmPTNww9AGOQ==
+  dependencies:
+    ember-cli-babel "^7.19.0"
+    ember-cli-typescript "^3.1.3"
+
 ember-load-initializers@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-2.1.1.tgz#d1a8bead00bc44222b0ab181840869992beb30f5"


### PR DESCRIPTION
part of https://github.com/GavinJoyce/embroider-spike/issues/7

It's nice that embroider catches things like this:

```
WARNING in ./node_modules/ember-lifeline/index.js 2:0-113
    "export 'Token' was not found in './poll-task'
     @ ./components/addons/ember-lifeline.js
     @ ./assets/embroider-spike.js
```