### PR TITLE
[spike] example of custom route map working with embroider

### DIFF
--- a/app/components/custom/component.hbs
+++ b/app/components/custom/component.hbs
@@ -1,0 +1,1 @@
+[This component is only used in the custom route]

--- a/app/components/nav.hbs
+++ b/app/components/nav.hbs
@@ -1,0 +1,12 @@
+<nav class="p-4 m-4 bg-gray-200">
+  <LinkTo @route="index" @activeClass="text-green-700">[Home]</LinkTo>
+  {{#if this.useCustomRouteMap}}
+    <LinkTo @route="custom" @activeClass="text-green-700">[Custom]</LinkTo>
+  {{else}}
+    <LinkTo @route="players" @activeClass="text-green-700">[Players]</LinkTo>
+    <LinkTo @route="teams" @activeClass="text-green-700">[Teams]</LinkTo>
+    <LinkTo @route="table" @activeClass="text-green-700">[Table]</LinkTo>
+    <LinkTo @route="parent" @activeClass="text-green-700">[Parent]</LinkTo>
+    <LinkTo @route="addons" @activeClass="text-green-700">[Addons]</LinkTo>
+  {{/if}}
+</nav>

--- a/app/components/nav.js
+++ b/app/components/nav.js
@@ -1,0 +1,5 @@
+import Component from "@glimmer/component";
+
+export default class extends Component {
+  useCustomRouteMap = window.USE_CUSTOM_ROUTE_MAP;
+}

--- a/app/index.html
+++ b/app/index.html
@@ -20,6 +20,10 @@
       href="{{rootURL}}assets/embroider-spike.css"
     />
 
+    <script>
+      window.USE_CUSTOM_ROUTE_MAP = window.location.search.includes("custom=true");
+    </script>
+
     {{content-for "head-footer"}}
   </head>
   <body>

--- a/app/router.js
+++ b/app/router.js
@@ -1,12 +1,24 @@
 import EmberRouter from "@embroider/router";
 import config from "./config/environment";
 
-export default class Router extends EmberRouter {
+const USE_CUSTOM_ROUTE_MAP = Boolean(window.USE_CUSTOM_ROUTE_MAP);
+
+export default class CustomRouter extends EmberRouter {
   location = config.locationType;
   rootURL = config.rootURL;
+
+  static map() {
+    if (USE_CUSTOM_ROUTE_MAP) {
+      super.map(function() {
+        this.route('custom');
+      });
+    } else {
+      super.map(...arguments);
+    }
+  }
 }
 
-Router.map(function () {
+CustomRouter.map(function () {
   this.route("players");
   this.route("teams");
   this.route("table");

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,13 +1,6 @@
-<h1 class="p-4 text-green-700 text-2xl">Welcome to embroider-spike</h1>
+<h1 class="p-4 text-2xl text-green-700">Welcome to embroider-spike</h1>
 
-<nav class="m-4 p-4 bg-gray-200">
-  <LinkTo @route="index" @activeClass="text-green-700">[Home]</LinkTo>
-  <LinkTo @route="players" @activeClass="text-green-700">[Players]</LinkTo>
-  <LinkTo @route="teams" @activeClass="text-green-700">[Teams]</LinkTo>
-  <LinkTo @route="table" @activeClass="text-green-700">[Table]</LinkTo>
-  <LinkTo @route="parent" @activeClass="text-green-700">[Parent]</LinkTo>
-  <LinkTo @route="addons" @activeClass="text-green-700">[Addons]</LinkTo>
-</nav>
+<Nav />
 
 <hr>
 

--- a/app/templates/custom.hbs
+++ b/app/templates/custom.hbs
@@ -1,0 +1,3 @@
+This the custom route
+
+<Custom::Component />

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -59,6 +59,7 @@ module.exports = function (defaults) {
       "parent",
       "parent.child",
       "parent.child.grandchild",
+      "custom"
     ],
   });
 };


### PR DESCRIPTION
A quick spike to see if embroider works with a boot time dynamic route map. It seems to work just fine, even with route splitting:

http://localhost:4200/:

![normal](https://user-images.githubusercontent.com/2526/104592173-b13a3680-5665-11eb-9405-393e49566b02.gif)

http://localhost:4200/?custom=true:

![custom](https://user-images.githubusercontent.com/2526/104592200-bc8d6200-5665-11eb-8c73-0da8b7d6b9f4.gif)

